### PR TITLE
docs: add NetEase client support properties to server config

### DIFF
--- a/docs/server-config/server-properties.mdx
+++ b/docs/server-config/server-properties.mdx
@@ -1060,3 +1060,17 @@ per world, consider increasing if you only have a few large worlds and lots of r
 | Boolean   | on            |
 
 Enable forced safety enchantments (up max lvl)
+
+## `netease-client-support`
+| Data Type | Default Value |
+|-----------|---------------|
+| Boolean   | off           |
+
+Enable NetEase client support will allow NetEase players to enter the server
+
+## `only-allow-netease-client`
+| Data Type | Default Value |
+|-----------|---------------|
+| Boolean   | off           |
+
+Only NetEase players are allowed to enter the server, and after opening, Microsoft version players will be prohibited from entering the server, and only NetEase players will be allowed to join the server

--- a/i18n/zh/docusaurus-plugin-content-docs/current/server-config/server-properties.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/server-config/server-properties.mdx
@@ -1060,3 +1060,17 @@ Hastebin 令牌，方便生成 debug 链接
 | Boolean   | on            |
 
 启用强制安全附魔（限制附魔最大等级）
+
+## `netease-client-support`
+| Data Type | Default Value |
+|-----------|---------------|
+| Boolean   | off           |
+
+启用网易客户端支持，启用后将允许网易玩家进入服务器
+
+## `only-allow-netease-client`
+| Data Type | Default Value |
+|-----------|---------------|
+| Boolean   | off           |
+
+仅允许网易玩家进入服务器，开启后将禁止微软版玩家进入服务器，仅允许网易玩家加入服务器


### PR DESCRIPTION
Add documentation for two new server properties:
- netease-client-support: Enable NetEase client support
- only-allow-netease-client: Restrict server to NetEase players only

Updated both English and Chinese documentation files.