### PR TITLE
fix: replace String.includes() with String.contains() in Java code examples

### DIFF
--- a/docs/developer-guide/guides/event.mdx
+++ b/docs/developer-guide/guides/event.mdx
@@ -90,7 +90,7 @@ public class EventListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerChat(PlayerChatEvent event) {
-        if (event.getMessage().includes("cnm")) { // Check if the message includes "cnm"
+        if (event.getMessage().contains("cnm")) { // Check if the message includes "cnm"
             event.setCancelled(true);
         }
     }

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developer-guide/guides/event.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developer-guide/guides/event.mdx
@@ -92,7 +92,7 @@ public class EventListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerChat(PlayerChatEvent event) {
-        if (event.getMessage().includes("cnm")) { // 检测消息中是否有 cnm
+        if (event.getMessage().contains("cnm")) { // 检测消息中是否有 cnm
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
## Summary
修复文档中 Java 示例代码的错误：String.includes() 不是 Java API，应使用 String.contains()。

## Changes
- docs/developer-guide/guides/event.mdx: 将 includes 替换为 contains
- i18n/zh/.../event.mdx: 同上（中文版）