### PR TITLE
fix: resolve Dependabot security alerts (websocket-driver, js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10137,9 +10137,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -17458,13 +17458,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -18725,7 +18718,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -19570,9 +19563,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
     "qs": "^6.15.2",
     "express": "^4.22.2",
     "body-parser": "^1.20.5",
-    "http-proxy-middleware": "^3.0.6"
+    "http-proxy-middleware": "^3.0.6",
+    "websocket-driver": "^0.7.5",
+    "gray-matter": {
+      "js-yaml": "^3.15.0"
+    }
   },
   "resolutions": {
     "serialize-javascript": "^7.0.5",
@@ -87,6 +91,10 @@
     "ws": "^8.21.0",
     "qs": "^6.15.2",
     "express": "^4.22.2",
-    "body-parser": "^1.20.5"
+    "body-parser": "^1.20.5",
+    "websocket-driver": "^0.7.5",
+    "gray-matter": {
+      "js-yaml": "^3.15.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Automated fix for open Dependabot security alerts.

**Alerts addressed:**

| Package | From | To | Severity | Notes |
|---|---|---|---|---|
| `websocket-driver` | 0.7.4 | 0.7.5 | **critical**, medium | 2 alerts (< 0.7.5) |
| `js-yaml` (via `gray-matter`) | 3.14.2 | 3.15.0 | medium | 1 alert (< 3.15.0) |

**Highest severity:** critical

**Approach:** Added npm `overrides` / `resolutions` entries (matching the existing pattern in `package.json`) to force patched versions of the transitive dependencies. The top-level `js-yaml@4.2.0` is not affected and is left untouched — the override is scoped to `gray-matter`'s nested `js-yaml` only.

**Verification:** `npm audit` reports `found 0 vulnerabilities` after the update.

🤖 AI Review auto-fix